### PR TITLE
use zope.interface.implementer instead of zope.interface.implements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- use zope.interface.implementer instead of zope.interface.implements
 
 
 1.0.0 (2019-05-13)

--- a/src/collective/cookiecuttr/browser/viewlet.py
+++ b/src/collective/cookiecuttr/browser/viewlet.py
@@ -8,12 +8,11 @@ from plone.memoize.view import memoize
 from plone.registry.interfaces import IRegistry
 from zope.component import getMultiAdapter
 from zope.component import getUtility
-from zope.interface import implements
+from zope.interface import implementer
 from zope.viewlet.interfaces import IViewlet
 
-
+@implementer(IViewlet)
 class CookieCuttrViewlet(BrowserView):
-    implements(IViewlet)
 
     def __init__(self, context, request, view, manager):
         super(CookieCuttrViewlet, self).__init__(context, request)


### PR DESCRIPTION
Using cookiecuttr 1.0.0 with python 3.6 fails with:
`File "/opt/plone/buildout-cache/eggs/collective.cookiecuttr-1.0.0-py3.6.egg/collective/cookiecuttr/browser/viewlet.py", line 19, in CookieCuttrViewlet
    implements(IViewlet)
....
TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.`

See also:
https://twistedmatrix.com/pipermail/twisted-python/2013-January/026414.html

Using implementer also works for python 2.7