### PR TITLE
Fix resource bundles on Plone 6.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- Fixed always failing validation in control panel on Plone 6.  [maurits]
+
 - Fix resource bundles on Plone 6.  [maurits]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix resource bundles on Plone 6.  [maurits]
 
 
 2.0.0 (2023-03-14)

--- a/src/collective/cookiecuttr/configure.zcml
+++ b/src/collective/cookiecuttr/configure.zcml
@@ -40,6 +40,13 @@
       handler=".upgrades.upgrade_from_0002_to_0003"
       profile="collective.cookiecuttr:default" />
 
+  <genericsetup:upgradeDepends
+      title="Fix resource bundle for Plone 6"
+      source="0003"
+      destination="0004"
+      import_steps="plone.app.registry"
+      profile="collective.cookiecuttr:default" />
+
   <genericsetup:registerProfile
       name="uninstall"
       title="collective.cookiecuttr uninstall profile"

--- a/src/collective/cookiecuttr/interfaces.py
+++ b/src/collective/cookiecuttr/interfaces.py
@@ -23,10 +23,12 @@ class ITextRowSchema(Interface):
     language = schema.TextLine(
         title=_(u"Language"),
         description=_(u'Enter the language code. Ex.: en'),
+        required=False,
     )
 
     text = schema.Text(
         title=_(u"Text"),
+        required=False,
     )
 
 
@@ -35,10 +37,12 @@ class ITextLinkSchema(Interface):
     language = schema.TextLine(
         title=_(u"Language"),
         description=_(u'Enter the language code. Ex.: en'),
+        required=False,
     )
 
     text = schema.Text(
         title=_(u"Link to page"),
+        required=False,
     )
 
 
@@ -47,10 +51,12 @@ class ITextAcceptSchema(Interface):
     language = schema.TextLine(
         title=_(u"Language"),
         description=_(u'Enter the language code. Ex.: en'),
+        required=False,
     )
 
     text = schema.Text(
         title=_(u"Text to show in the Accept button"),
+        required=False,
     )
 
 

--- a/src/collective/cookiecuttr/profiles/default/metadata.xml
+++ b/src/collective/cookiecuttr/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>0003</version>
+  <version>0004</version>
   <dependencies>
       <dependency>profile-plone.app.registry:default</dependency>
       <dependency>profile-collective.z3cform.datagridfield:default</dependency>

--- a/src/collective/cookiecuttr/profiles/default/registry.xml
+++ b/src/collective/cookiecuttr/profiles/default/registry.xml
@@ -1,8 +1,29 @@
 <?xml version="1.0"?>
 <registry>
+ <!-- all Plone versions -->
  <records interface="collective.cookiecuttr.interfaces.ICookieCuttrSettings" />
 
+ <!-- Plone 6 -->
+ <records prefix="plone.bundles/cookiecuttr-cookie"
+          condition="have plone-60"
+          interface='Products.CMFPlone.interfaces.IBundleRegistry'>
+   <value key="enabled">True</value>
+   <value key="csscompilation"></value>
+   <value key="jscompilation">++resource++collective.cookiecuttr/jquery.cookie.js</value>
+   <value key="depends">plone</value>
+ </records>
+ <records prefix="plone.bundles/cookiecuttr"
+          condition="have plone-60"
+          interface='Products.CMFPlone.interfaces.IBundleRegistry'>
+   <value key="enabled">True</value>
+   <value key="csscompilation">++resource++collective.cookiecuttr/cookiecuttr.min.css</value>
+   <value key="jscompilation">++resource++collective.cookiecuttr/cookiecuttr.min.js</value>
+   <value key="depends">cookiecuttr-cookie</value>
+ </records>
+
+ <!-- Plone 5.2 -->
  <records prefix="plone.resources/cookiecuttr"
+          condition="not-have plone-60"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
      <value key="js">++resource++collective.cookiecuttr/cookiecuttr.min.js</value>
      <value key="deps">jquery</value>
@@ -12,11 +33,13 @@
  </records>
 
  <records prefix="plone.resources/cookiecuttr-cookie"
+          condition="not-have plone-60"
           interface='Products.CMFPlone.interfaces.IResourceRegistry'>
      <value key="js">++resource++collective.cookiecuttr/jquery.cookie.js</value>
  </records>
 
  <records prefix="plone.bundles/cookiecuttr"
+          condition="not-have plone-60"
           interface='Products.CMFPlone.interfaces.IBundleRegistry'>
    <value key="resources">
      <element>cookiecuttr-cookie</element>


### PR DESCRIPTION
In Plone 6 you only register resource bundles, not individual resources. In our case we need two bundles: one for our main css and js, and one for jquery.cookie.

Fixes one part of issue #10.